### PR TITLE
respect proxy environment variables

### DIFF
--- a/lib/Travel/Routing/DE/VRR.pm
+++ b/lib/Travel/Routing/DE/VRR.pm
@@ -411,6 +411,7 @@ sub submit {
 	my ( $self, %conf ) = @_;
 
 	$self->{ua} = LWP::UserAgent->new(%conf);
+	$self->{ua}->env_proxy;
 
 	my $response = $self->{ua}
 	  ->post( 'http://efa.vrr.de/vrr/XSLT_TRIP_REQUEST2', $self->{post} );


### PR DESCRIPTION
This little patch makes Travel::Routing::DE::VRR respect the HTTP_PROXY
environment variable, which is the standard environment variable for proxy
configuration and is also used by many other applications.
