### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,7 @@ To install the latest release, run:
 
 ```
 wget https://lib.finalrewind.org/deb/libtravel-routing-de-vrr-perl_latest_all.deb
-sudo dpkg -i libtravel-routing-de-vrr-perl_latest_all.deb
-sudo apt --fix-broken install
+sudo apt install ./libtravel-routing-de-vrr-perl_latest_all.deb
 rm libtravel-routing-de-vrr-perl_latest_all.deb
 ```
 
@@ -47,16 +46,9 @@ For a (possibly broken) development snapshot of the Git master branch, run:
 
 ```
 wget https://lib.finalrewind.org/deb/libtravel-routing-de-vrr-perl_dev_all.deb
-sudo dpkg -i libtravel-routing-de-vrr-perl_dev_all.deb
-sudo apt --fix-broken install
+sudo apt install ./libtravel-routing-de-vrr-perl_dev_all.deb
 rm libtravel-routing-de-vrr-perl_dev_all.deb
 ```
-
-Note that dpkg, unlike apt, does not automatically install missing
-dependencies. If a dependency is not satisfied yet, `dpkg -i` will complain
-about unmet dependencies and bail out. `apt --fix-broken install` installs
-these dependencies and also silently finishes the Travel::Routing::DE::VRR
-installation.
 
 Uninstallation works as usual:
 


### PR DESCRIPTION
Simplify instrucations for manually installing the nightly Debian packages.

`apt` can be used to install `*.deb` files (if given a path, hence the `./`), and takes care of dependencies.